### PR TITLE
Fix ShowcaseCard ref handling

### DIFF
--- a/src/app/(landing)/_components/playground/_components/showcaseCard.tsx
+++ b/src/app/(landing)/_components/playground/_components/showcaseCard.tsx
@@ -1,15 +1,12 @@
 import { motion, useScroll, useTransform } from "framer-motion";
-import React, { useRef } from "react";
+import React from "react";
 
-type Props = {
-  ref: React.RefObject<HTMLDivElement | null>;
-};
-
-const ShowcaseCard = ({ ref }: Props) => {
-  const { scrollYProgress } = useScroll({
-    target: ref,
-    offset: ["start start", "end center"],
-  });
+const ShowcaseCard = React.forwardRef<HTMLDivElement, Record<string, never>>(
+  (props, ref) => {
+    const { scrollYProgress } = useScroll({
+      target: ref,
+      offset: ["start start", "end center"],
+    });
 
   const opacity1 = useTransform(scrollYProgress, [0, 0.1], [0, 1]);
   const y1 = useTransform(scrollYProgress, [0, 0.1], [-300, 0]);
@@ -65,6 +62,7 @@ const ShowcaseCard = ({ ref }: Props) => {
       </motion.div>
     </motion.div>
   );
-};
+  },
+);
 
 export default ShowcaseCard;


### PR DESCRIPTION
## Summary
- update `ShowcaseCard` component to accept forwarded `ref`

## Testing
- `npx tsc` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685d4974c0108331bf079f5c44a2d98e