### PR TITLE
Add crypto import in login action

### DIFF
--- a/src/action/login.ts
+++ b/src/action/login.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db";
 import { createClient } from "@/utils/supabase/client";
 import { createClientServer } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
+import crypto from "crypto";
 
 export const GitHubLogin = async () => {
   const supabase = createClient();


### PR DESCRIPTION
## Summary
- add missing `crypto` import to `src/action/login.ts`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687be7a7d4a08331bbef9aafd31bd1cd